### PR TITLE
Instrument handlers by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 [lib]
 proc-macro = true
 
+[features]
+tracing = []
+
 [dependencies]
 quote = "1"
 syn = { version = "1", features = ["full"] }


### PR DESCRIPTION
This PR makes the `#[xtra_productivity]` attribute automatically propagate attributes, as well as add `#[instrument]` attributes where missing