### PR TITLE
Rename tracing feature to 'instrumentation'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           toolchain: stable
           components: clippy
       - uses: Swatinem/rust-cache@v1.3.0
-      - run: cargo clippy --workspace --all-targets -- -D warnings
+      - run: cargo clippy --workspace --all-features --all-targets -- -D warnings
 
   test:
     strategy:
@@ -38,4 +38,4 @@ jobs:
         run: rustup show
       - uses: Swatinem/rust-cache@v1.3.0
       - run: cargo build --tests
-      - run: cargo test --workspace
+      - run: cargo test --features instrumentation --workspace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "event-listener"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,6 +88,12 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "once_cell"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
 
 [[package]]
 name = "pin-project-lite"
@@ -192,6 +204,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6b8ad3567499f98a1db7a752b07a7c8c7c7c34c332ec00effb2b0027974b7c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "trybuild"
 version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,6 +301,7 @@ dependencies = [
  "pin-project-lite",
  "pollster",
  "spin",
+ "tracing",
 ]
 
 [[package]]
@@ -266,6 +311,7 @@ dependencies = [
  "async-trait",
  "quote",
  "syn",
+ "tracing",
  "trybuild",
  "xtra",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 proc-macro = true
 
 [features]
-tracing = []
+instrumentation = []
 
 [dependencies]
 quote = "1"
@@ -15,8 +15,9 @@ syn = { version = "1", features = ["full"] }
 
 [dev-dependencies]
 async-trait = "0.1"
+tracing = { version = "0.1" }
 trybuild = "1"
-xtra = "0.6"
+xtra = { version = "0.6", features = ["instrumentation"] }
 
 [patch.crates-io]
 xtra = { git = "https://github.com/Restioson/xtra" } # Latest master has crucial patches.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ pub fn xtra_productivity(_attribute: TokenStream, item: TokenStream) -> TokenStr
 
             let attrs = method.attrs;
 
-            #[cfg(feature = "tracing")]
+            #[cfg(feature = "instrumentation")]
             let instrument = if !attrs.iter().any(|attr| attr.path.segments.last().unwrap().ident == "instrument") {
                 let name = format!("Handle {}", quote!(#message_type));
 
@@ -77,7 +77,7 @@ pub fn xtra_productivity(_attribute: TokenStream, item: TokenStream) -> TokenStr
                 quote! {}
             };
 
-            #[cfg(not(feature = "tracing"))]
+            #[cfg(not(feature = "instrumentation"))]
             let instrument = quote!();
 
             quote! {


### PR DESCRIPTION
Feature name is consistent with `xtra` now.

Also, add tracing dev dependency (required to run tests with feature enabled):

```
cargo test --features instrumentation
```